### PR TITLE
Update docker-compose definition and improve services script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,9 +54,11 @@ services:
 
 networks:
   default:
+    name: tutorials.Roles-Permissions
     ipam:
       config:
         - subnet: 172.18.1.0/24
+
 volumes:
   mysql-db: ~
 

--- a/services
+++ b/services
@@ -35,16 +35,9 @@ startContainers () {
 }
 
 stoppingContainers () {
-	CONTAINERS=$(docker ps -aq)
-	if [[ -n $CONTAINERS ]]; then 
-		echo "Stopping containers"
-		docker rm -f $CONTAINERS
-	fi
-	VOLUMES=$(docker volume ls -qf dangling=true) 
-	if [[ -n $VOLUMES ]]; then 
-		echo "Removing old volumes"
-		docker volume rm $VOLUMES
-	fi
+	echo ""
+	${dockerCmd} down -v --remove-orphans
+	echo ""
 }
 
 waitForKeyrock () {


### PR DESCRIPTION
# Description
- Just adding name property in the definition of the network to allow naming network always with the same name.
- Change services bash script to execute the docker-compose down and not remove all the docker containers and volumes deployed in the docket engine

# Testing
Executed the tutorial until request 01 to check it is working and afterwards ./services down